### PR TITLE
fix(ci): use npm Trusted Publishing instead of access token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release
@@ -16,6 +21,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm install -g npm@latest
 
       - uses: oven-sh/setup-bun@v2
 
@@ -24,12 +32,17 @@ jobs:
       - run: bun run typecheck
 
       - name: Create Release PR or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
-          publish: bun run release
           version: bun run version
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          cd packages/schema
+          npm publish --provenance --access public

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -21,7 +21,8 @@
     "!scripts/**"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Replace NPM_TOKEN-based auth with OIDC Trusted Publishing for more secure npm publishing.

## Changes

- **Workflow**: Add `id-token: write` permission for OIDC authentication
- **Workflow**: Separate versioning (`changesets/action`) from publishing (`npm publish --provenance`)
- **Workflow**: Remove `NPM_TOKEN` dependency — OIDC replaces it
- **Workflow**: Install latest npm (>= 11.5.1 required for Trusted Publishing)
- **package.json**: Add `provenance: true` to `publishConfig` for supply chain attestation

## Required: Configure Trusted Publisher on npmjs.com

After merging, configure the Trusted Publisher on npm before the next publish:

1. Go to https://www.npmjs.com/package/@osprotocol/schema/access
2. Under **Trusted Publishers** → **Add a Trusted Publisher**
3. Select **GitHub Actions** and fill in:
   - **Repository owner**: `synerops`
   - **Repository name**: `osprotocol`
   - **Workflow filename**: `release.yml`
4. Save

Once configured, the Release workflow will authenticate via OIDC — no tokens needed.

## Why

The previous approach used an `NPM_TOKEN` secret which was blocked by npm's 2FA/OTP requirement. Trusted Publishing uses OIDC (OpenID Connect) between GitHub Actions and npm, which:
- Eliminates long-lived credentials
- Bypasses 2FA prompts in CI
- Adds cryptographic provenance attestations to published packages
- Is npm's recommended approach for CI/CD