### PR TITLE
fix(ci): skip publish when version already exists on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,11 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           cd packages/schema
-          npm publish --provenance --access public
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          NPM_VERSION=$(npm view @osprotocol/schema version 2>/dev/null || echo "0.0.0")
+          if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
+            echo "Publishing @osprotocol/schema@$LOCAL_VERSION (npm has $NPM_VERSION)"
+            npm publish --provenance --access public
+          else
+            echo "Skipping publish: @osprotocol/schema@$LOCAL_VERSION already published"
+          fi


### PR DESCRIPTION
The publish step now compares local version against npm before attempting to publish. This prevents failures when the version was already published (e.g., manually for the initial release).

If versions match, the step logs a skip message and exits cleanly.