### PR TITLE
Phase 3: Draft @experimental interfaces for all Extension files

### DIFF
--- a/packages/schema/actions/mcp-servers.ts
+++ b/packages/schema/actions/mcp-servers.ts
@@ -1,0 +1,87 @@
+/**
+ * MCP Servers
+ *
+ * @experimental No real implementation yet.
+ *
+ * Agent-facing interface for interacting with MCP servers.
+ * While tools from MCP servers are accessible via the
+ * unified Tools interface, this provides direct access
+ * to MCP-specific capabilities: resources and prompts.
+ * The infrastructure side lives in system/mcp-client.ts.
+ * (Anthropic MCP, AAIF MCP Standard).
+ */
+
+/**
+ * An MCP resource
+ */
+export interface McpResource {
+  /** Resource URI */
+  uri: string
+  /** Human-readable name */
+  name: string
+  /** MIME type of the resource content */
+  mimeType?: string
+  /** Resource description */
+  description?: string
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * An MCP prompt
+ */
+export interface McpPrompt {
+  /** Prompt name */
+  name: string
+  /** Human-readable description */
+  description?: string
+  /** Arguments the prompt accepts */
+  arguments?: object
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * MCP server interaction interface
+ *
+ * Provides agent-facing access to MCP server capabilities
+ * beyond tool execution. Resources expose data and content,
+ * prompts provide reusable templates. Tool execution goes
+ * through the unified Tools interface.
+ */
+export interface McpServers {
+  /**
+   * List resources from a connected MCP server
+   *
+   * @param server - MCP server name
+   * @returns Array of available resources
+   */
+  listResources(server: string): Promise<McpResource[]>
+
+  /**
+   * Read a resource from an MCP server
+   *
+   * @param server - MCP server name
+   * @param uri - Resource URI
+   * @returns Resource content as string, or null if not found
+   */
+  readResource(server: string, uri: string): Promise<string | null>
+
+  /**
+   * List prompts from a connected MCP server
+   *
+   * @param server - MCP server name
+   * @returns Array of available prompts
+   */
+  listPrompts(server: string): Promise<McpPrompt[]>
+
+  /**
+   * Get a prompt from an MCP server
+   *
+   * @param server - MCP server name
+   * @param name - Prompt name
+   * @param args - Prompt arguments
+   * @returns The rendered prompt content, or null if not found
+   */
+  getPrompt(server: string, name: string, args?: Record<string, string>): Promise<string | null>
+}

--- a/packages/schema/actions/system.ts
+++ b/packages/schema/actions/system.ts
@@ -1,0 +1,56 @@
+/**
+ * System Actions
+ *
+ * @experimental No real implementation yet.
+ *
+ * Write operations for all system state during the
+ * actions phase of the agent loop. Pure composition —
+ * each system API owns its own Actions interface.
+ * Read operations live in context/system.ts.
+ */
+
+import type { EnvActions } from '../system/env'
+import type { SettingsActions } from '../system/settings'
+import type { PreferencesActions } from '../system/preferences'
+import type { RegistryActions } from '../system/registry'
+import type { FsActions } from '../system/fs'
+import type { SandboxActions } from '../system/sandbox'
+import type { InstallerActions } from '../system/installer'
+import type { McpActions } from '../system/mcp-client'
+
+export type {
+  EnvActions,
+  SettingsActions,
+  PreferencesActions,
+  RegistryActions,
+  FsActions,
+  SandboxActions,
+  InstallerActions,
+  McpActions,
+}
+
+/**
+ * System write operations interface
+ *
+ * Composes all system write interfaces into a single
+ * entry point for the actions phase of the agent loop.
+ * All mutations go through this interface.
+ */
+export interface SystemActions {
+  /** Environment variables */
+  env: EnvActions
+  /** System-wide settings */
+  settings: SettingsActions
+  /** Scoped preferences */
+  preferences: PreferencesActions
+  /** Resource registries */
+  registry: RegistryActions
+  /** Host filesystem */
+  fs: FsActions
+  /** Sandbox environments */
+  sandbox: SandboxActions
+  /** Installed packages */
+  installer: InstallerActions
+  /** MCP server connections */
+  mcp: McpActions
+}

--- a/packages/schema/actions/tools.ts
+++ b/packages/schema/actions/tools.ts
@@ -1,0 +1,81 @@
+/**
+ * Tools
+ *
+ * @experimental No real implementation yet.
+ *
+ * Tool discovery and execution for the actions phase.
+ * The agent-facing interface for invoking tools regardless
+ * of their source (MCP servers, built-in, custom).
+ * (Anthropic MCP Tools, OpenAI Function Calling,
+ * Vercel AI SDK Tools, LangChain Tools).
+ */
+
+/**
+ * Tool definition
+ *
+ * @template TParams - The type of tool parameters
+ * @template TResult - The type of tool result
+ */
+export interface Tool<TParams = unknown, TResult = unknown> {
+  /** Tool name */
+  name: string
+  /** Human-readable description */
+  description: string
+  /** JSON Schema for parameters */
+  parameters?: object
+  /** Execute the tool */
+  execute(params: TParams): Promise<TResult>
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Tool execution result
+ */
+export interface ToolResult<T = unknown> {
+  /** The tool that was executed */
+  toolName: string
+  /** Execution result */
+  result: T
+  /** Whether execution succeeded */
+  success: boolean
+  /** Error message if execution failed */
+  error?: string
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Tool management and execution interface
+ *
+ * Provides discovery and invocation of tools from any
+ * source. Implementations aggregate tools from MCP
+ * servers, built-in capabilities, and custom providers
+ * into a unified execution surface.
+ */
+export interface Tools {
+  /**
+   * Get a tool by name
+   *
+   * @param name - Tool name
+   * @returns The tool, or null if not found
+   */
+  get(name: string): Promise<Tool | null>
+
+  /**
+   * List all available tools
+   *
+   * @returns Array of available tools
+   */
+  list(): Promise<Tool[]>
+
+  /**
+   * Execute a tool by name
+   *
+   * @template T - The type of the result
+   * @param name - Tool name
+   * @param params - Tool parameters
+   * @returns The execution result
+   */
+  execute<T = unknown>(name: string, params?: unknown): Promise<ToolResult<T>>
+}

--- a/packages/schema/apps/schema.ts
+++ b/packages/schema/apps/schema.ts
@@ -1,1 +1,153 @@
+/**
+ * App Schema
+ *
+ * @experimental No real implementation yet.
+ *
+ * Agentic OS distribution manifest format. Defines the
+ * YAML frontmatter types for distribution files (e.g.
+ * SYNER.md, APP.md, ACADEMY.md — the filename is up
+ * to the author, the format is what matters).
+ *
+ * An "app" is a distribution of the Agentic OS: it
+ * declares which vendors implement which protocol
+ * interfaces. Like AGENT.md defines an agent and
+ * SKILL.md defines a skill, the app file defines
+ * a complete agentic system configuration.
+ *
+ * The markdown body is free-form documentation —
+ * instructions, architecture notes, onboarding guides.
+ * The frontmatter is the structured, machine-readable
+ * distribution manifest.
+ *
+ * Cross-referenced: package.json, Docker Compose,
+ * Helm Chart.yaml, claude_desktop_config.json,
+ * Cursor mcp.json, VS Code mcp.json, vercel.json.
+ */
 
+// ---------------------------------------------------------------------------
+// Provider Bindings
+// ---------------------------------------------------------------------------
+
+/**
+ * A provider binding
+ *
+ * Maps an abstract protocol interface to a concrete
+ * vendor implementation. Each entry in the providers
+ * map declares who implements what.
+ *
+ * ```yaml
+ * providers:
+ *   system:
+ *     env:
+ *       provider: '@vercel/env'
+ *     sandbox:
+ *       provider: '@vercel/sandbox'
+ *       version: '^1.0.0'
+ * ```
+ */
+export interface ProviderEntry {
+  /** Provider package or identifier */
+  provider: string
+  /** Provider version (SemVer range) */
+  version?: string
+  /** Whether this provider is enabled */
+  enabled?: boolean
+  /** Extensible metadata for provider-specific config */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Provider bindings organized by protocol domain
+ *
+ * Maps each protocol domain's interfaces to their
+ * concrete vendor implementations. Granularity is
+ * per individual interface, not per domain.
+ *
+ * ```yaml
+ * providers:
+ *   system:
+ *     env: { provider: '@vercel/env' }
+ *     fs: { provider: '@vercel/blob' }
+ *     sandbox: { provider: '@vercel/sandbox' }
+ *   context:
+ *     embeddings: { provider: '@upstash/vector' }
+ *   checks:
+ *     screenshot: { provider: 'playwright' }
+ *     judge: { provider: '@braintrust/judge' }
+ * ```
+ */
+export interface ProviderMap {
+  /** System-level interface providers */
+  system?: Record<string, ProviderEntry>
+  /** Context-level interface providers */
+  context?: Record<string, ProviderEntry>
+  /** Actions-level interface providers */
+  actions?: Record<string, ProviderEntry>
+  /** Checks-level interface providers */
+  checks?: Record<string, ProviderEntry>
+}
+
+// ---------------------------------------------------------------------------
+// App Metadata (YAML frontmatter)
+// ---------------------------------------------------------------------------
+
+/**
+ * App metadata (YAML frontmatter in the distribution file)
+ *
+ * Follows the same pattern as AgentMetadata and
+ * SkillMetadata — structured data in YAML frontmatter,
+ * free-form markdown body.
+ *
+ * ```yaml
+ * ---
+ * name: '@synerops/syner-os'
+ * version: '1.0.0'
+ * description: 'Syner OS — AI-powered development platform'
+ * protocol: '0.1.0'
+ * providers:
+ *   system:
+ *     sandbox: { provider: '@vercel/sandbox' }
+ *     fs: { provider: '@vercel/blob' }
+ *   context:
+ *     embeddings: { provider: '@upstash/vector' }
+ * ---
+ *
+ * # Syner OS
+ *
+ * Syner OS is an AI-powered development platform...
+ * ```
+ */
+export interface AppMetadata {
+  /** Distribution name (scoped, e.g. '@org/my-os') */
+  name: string
+  /** SemVer version */
+  version: string
+  /** Human-readable description */
+  description?: string
+  /** Minimum OS Protocol version required */
+  protocol?: string
+  /** Provider bindings per protocol domain */
+  providers?: ProviderMap
+  /** Extensible metadata for distribution-specific data */
+  metadata?: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Full App Definition
+// ---------------------------------------------------------------------------
+
+/**
+ * Full App definition (metadata + content from distribution file)
+ *
+ * Follows the same pattern as Agent and Skill:
+ * metadata from YAML frontmatter, content from
+ * markdown body, path to the source file.
+ */
+export interface App {
+  /** Metadata from YAML frontmatter */
+  metadata: AppMetadata
+  /** Markdown content (documentation, instructions) */
+  content: string
+  /** File path where the distribution file was loaded from */
+  path: string
+}

--- a/packages/schema/checks/audit.ts
+++ b/packages/schema/checks/audit.ts
@@ -1,1 +1,69 @@
+/**
+ * Audit
+ *
+ * @experimental No real implementation yet.
+ *
+ * Verification audit trail for recording check results.
+ * The checks-phase interface for logging what was verified,
+ * when, and with what outcome
+ * (GitHub Audit Log, Datadog, Braintrust Logs,
+ * LangSmith Traces).
+ */
 
+import type { RuleResult } from './rules'
+import type { JudgeResult } from './judge'
+
+/**
+ * An audit log entry
+ */
+export interface AuditEntry {
+  /** Unique identifier */
+  id: string
+  /** When this entry was created (Unix ms) */
+  createdAt: number
+  /** Agent that produced the verified content */
+  agentId?: string
+  /** Execution or run ID this audit belongs to */
+  executionId?: string
+  /** Rule evaluation results */
+  ruleResults?: RuleResult[]
+  /** Judge evaluation result */
+  judgeResult?: JudgeResult
+  /** Whether all checks passed */
+  passed: boolean
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Verification audit interface
+ *
+ * Provides logging and retrieval of check results.
+ * Every verification (rules, judge) gets recorded
+ * for compliance, debugging, and trust scoring.
+ */
+export interface Audit {
+  /**
+   * Log a verification result
+   *
+   * @param entry - Audit entry to record
+   * @returns The recorded entry with generated ID
+   */
+  log(entry: Omit<AuditEntry, 'id' | 'createdAt'>): Promise<AuditEntry>
+
+  /**
+   * Get an audit entry by ID
+   *
+   * @param id - Audit entry identifier
+   * @returns The entry, or null if not found
+   */
+  get(id: string): Promise<AuditEntry | null>
+
+  /**
+   * List audit entries for an execution
+   *
+   * @param executionId - Execution or run ID
+   * @returns Array of audit entries
+   */
+  list(executionId: string): Promise<AuditEntry[]>
+}

--- a/packages/schema/checks/judge.ts
+++ b/packages/schema/checks/judge.ts
@@ -1,18 +1,62 @@
 /**
- * Judge — LLM-as-Judge verification
+ * Judge
  *
- * Defines how an LLM evaluates agent output against rules.
- * Not just "pass/fail" — the protocol standardizes:
+ * @experimental No real implementation yet.
  *
- * - Which model evaluates (judge model config)
- * - What prompt/criteria it uses (linked to rules.ts)
- * - How scoring is structured (rubric, scale, binary)
- * - What threshold determines pass/fail
- * - How the evaluation result feeds back (to audit.ts, to runs/approval.ts)
- *
- * The protocol is agnostic about implementation (could be LLM, regex, human)
- * but LLM-as-judge is a first-class pattern worth standardizing because
- * it requires its own configuration surface.
- *
- * Status: Extension (draft)
+ * LLM-as-judge verification for evaluating agent output
+ * against quality criteria. The checks-phase interface
+ * for scoring and grading with reasoning
+ * (OpenAI Evals, Braintrust Scorers, LangSmith
+ * Evaluators, Arize Phoenix).
  */
+
+import type { RuleResult } from './rules'
+
+/**
+ * Judge configuration
+ */
+export interface JudgeConfig {
+  /** Model identifier for the judge LLM */
+  model?: string
+  /** Evaluation criteria or rubric */
+  criteria: string
+  /** Score threshold for passing (0-1) */
+  threshold?: number
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Judge evaluation result
+ */
+export interface JudgeResult {
+  /** Score between 0 and 1 */
+  score: number
+  /** Whether the evaluation passed the threshold */
+  passed: boolean
+  /** LLM reasoning for the score */
+  reasoning: string
+  /** Optional breakdown by criteria */
+  ruleResults?: RuleResult[]
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * LLM-as-judge evaluation interface
+ *
+ * Provides model-based evaluation of agent output.
+ * Judges score content against criteria with reasoning.
+ * Results feed into audit.ts and may trigger
+ * runs/approval when below threshold.
+ */
+export interface Judge {
+  /**
+   * Evaluate content against criteria
+   *
+   * @param content - Content to evaluate
+   * @param config - Judge configuration with criteria
+   * @returns The evaluation result with score and reasoning
+   */
+  evaluate(content: unknown, config: JudgeConfig): Promise<JudgeResult>
+}

--- a/packages/schema/checks/rules.ts
+++ b/packages/schema/checks/rules.ts
@@ -1,0 +1,81 @@
+/**
+ * Verification Rules
+ *
+ * @experimental No real implementation yet.
+ *
+ * Declarative verification criteria for agent output.
+ * The checks-phase interface for defining what must be
+ * satisfied before output is accepted
+ * (ESLint Rules, GitHub Checks, Vercel Deployment
+ * Checks, OpenAI Guardrails).
+ */
+
+/**
+ * Rule severity level
+ */
+export type RuleSeverity = 'error' | 'warning' | 'info'
+
+/**
+ * Rule evaluation result
+ */
+export interface RuleResult {
+  /** Rule that was evaluated */
+  ruleName: string
+  /** Whether the rule passed */
+  passed: boolean
+  /** Severity of this rule */
+  severity: RuleSeverity
+  /** Human-readable message explaining the result */
+  message: string
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * A verification rule definition
+ */
+export interface Rule {
+  /** Rule name */
+  name: string
+  /** Human-readable description */
+  description: string
+  /** Severity level */
+  severity: RuleSeverity
+  /** Evaluate this rule against content */
+  evaluate(content: unknown): Promise<RuleResult>
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Verification rules management interface
+ *
+ * Provides declarative verification criteria that agent
+ * output must satisfy. Rules are composable and can be
+ * evaluated individually or as a set. Results feed into
+ * audit.ts and may trigger runs/approval.
+ */
+export interface Rules {
+  /**
+   * Get a rule by name
+   *
+   * @param name - Rule name
+   * @returns The rule, or null if not found
+   */
+  get(name: string): Promise<Rule | null>
+
+  /**
+   * List all available rules
+   *
+   * @returns Array of all rules
+   */
+  list(): Promise<Rule[]>
+
+  /**
+   * Evaluate all rules against content
+   *
+   * @param content - Content to verify
+   * @returns Array of results for each rule
+   */
+  evaluate(content: unknown): Promise<RuleResult[]>
+}

--- a/packages/schema/checks/screenshot.ts
+++ b/packages/schema/checks/screenshot.ts
@@ -1,0 +1,134 @@
+/**
+ * Screenshot
+ *
+ * @experimental No real implementation yet.
+ *
+ * Visual capture and verification for agent output.
+ * The checks-phase interface for taking screenshots
+ * and comparing them against baselines for visual
+ * regression detection
+ * (Playwright, Puppeteer, Browserbase, ScreenshotOne).
+ */
+
+/**
+ * Image format for screenshots
+ *
+ * Universal across all providers. PNG for lossless
+ * (best for diff), JPEG/WebP for smaller payloads.
+ */
+export type ImageFormat = 'png' | 'jpeg' | 'webp'
+
+/**
+ * Screenshot capture options
+ *
+ * Convergent surface across Playwright, Puppeteer,
+ * Browserbase (CDP), and ScreenshotOne.
+ */
+export interface ScreenshotOptions {
+  /** Target URL (required for SaaS providers, optional for browser SDKs) */
+  url?: string
+  /** Capture the full scrollable page instead of just the viewport */
+  fullPage?: boolean
+  /** Clip to a specific region */
+  clip?: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
+  /** CSS selector to capture a specific element */
+  selector?: string
+  /** Image format */
+  format?: ImageFormat
+  /** Quality (0-100). Ignored for PNG. */
+  quality?: number
+  /** DPI multiplier (e.g. 2 for retina) */
+  scale?: number
+  /** Transparent background (PNG/WebP only) */
+  omitBackground?: boolean
+  /** Extensible metadata for provider-specific options */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * A captured screenshot
+ */
+export interface ScreenshotEntry {
+  /** Unique identifier */
+  id: string
+  /** Base64-encoded image data */
+  data: string
+  /** Image format */
+  format: ImageFormat
+  /** Image width in pixels */
+  width: number
+  /** Image height in pixels */
+  height: number
+  /** When this screenshot was taken (Unix ms) */
+  createdAt: number
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Visual comparison result
+ *
+ * Produced by comparing two screenshots. Connects
+ * to the checks pattern — passed/message like RuleResult.
+ */
+export interface ComparisonResult {
+  /** Whether the screenshots match within threshold */
+  passed: boolean
+  /** Human-readable explanation */
+  message: string
+  /** Number of pixels that differ */
+  diffPixels: number
+  /** Ratio of different pixels (0-1) */
+  diffRatio: number
+  /** Base64-encoded diff image showing differences */
+  diffImage?: string
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Visual verification interface
+ *
+ * Provides screenshot capture and baseline comparison
+ * for visual regression detection. Capture is the means;
+ * comparison result feeds into audit.ts alongside
+ * RuleResult and JudgeResult.
+ *
+ * Only Playwright has built-in diff (toHaveScreenshot
+ * via Pixelmatch). Other providers require external
+ * comparison — the provider adapter handles this.
+ */
+export interface Screenshot {
+  /**
+   * Capture a screenshot
+   *
+   * Maps to:
+   * - Playwright: page.screenshot(options)
+   * - Puppeteer: page.screenshot(options)
+   * - Browserbase: CDP Page.captureScreenshot
+   * - ScreenshotOne: GET /take?url=...
+   *
+   * @param options - Capture options
+   * @returns The captured screenshot
+   */
+  capture(options?: ScreenshotOptions): Promise<ScreenshotEntry>
+
+  /**
+   * Compare two screenshots
+   *
+   * @param actual - Screenshot to verify
+   * @param baseline - Expected screenshot
+   * @param threshold - Maximum acceptable diff ratio (0-1, defaults to 0)
+   * @returns Comparison result with pass/fail and diff data
+   */
+  compare(
+    actual: ScreenshotEntry,
+    baseline: ScreenshotEntry,
+    threshold?: number,
+  ): Promise<ComparisonResult>
+}

--- a/packages/schema/context/embeddings.ts
+++ b/packages/schema/context/embeddings.ts
@@ -1,0 +1,84 @@
+/**
+ * Embeddings
+ *
+ * @experimental No real implementation yet.
+ *
+ * Vector embeddings and similarity search.
+ * The agent-facing interface for semantic search over
+ * indexed knowledge. The vector database is a System
+ * concern underneath (Pinecone, Upstash Vector,
+ * Weaviate, OpenAI Embeddings).
+ */
+
+/**
+ * A vector embedding entry
+ *
+ * @template T - The type of associated metadata
+ */
+export interface EmbeddingEntry<T = Record<string, unknown>> {
+  /** Unique identifier */
+  id: string
+  /** Original content that was embedded */
+  content: string
+  /** Similarity score (0-1, present only in search results) */
+  score?: number
+  /** Extensible metadata for filtering and provider-specific data */
+  metadata?: T
+}
+
+/**
+ * Embeddings capability interface
+ *
+ * Provides semantic indexing and similarity search.
+ * Agents use this to find relevant context by meaning,
+ * not just keywords. Implementations map to vector
+ * databases and embedding model providers.
+ */
+export interface Embeddings {
+  /**
+   * Upsert content by generating and storing its embedding
+   *
+   * @template T - The type of associated metadata
+   * @param id - Entry identifier
+   * @param content - Text content to embed and store
+   * @param metadata - Optional metadata for filtering
+   * @returns The stored entry
+   */
+  upsert<T = Record<string, unknown>>(
+    id: string,
+    content: string,
+    metadata?: T
+  ): Promise<EmbeddingEntry<T>>
+
+  /**
+   * Search for similar content
+   *
+   * @template T - The type of associated metadata
+   * @param query - Text to search for
+   * @param topK - Maximum number of results to return
+   * @param filter - Metadata filter criteria
+   * @returns Array of entries sorted by similarity (highest first)
+   */
+  search<T = Record<string, unknown>>(
+    query: string,
+    topK: number,
+    filter?: Partial<T>
+  ): Promise<EmbeddingEntry<T>[]>
+
+  /**
+   * Get an entry by ID
+   *
+   * @template T - The type of associated metadata
+   * @param id - Entry identifier
+   * @returns The entry, or null if not found
+   */
+  get<T = Record<string, unknown>>(id: string): Promise<EmbeddingEntry<T> | null>
+
+  /**
+   * Remove an entry
+   *
+   * @param id - Entry identifier
+   * @returns true if the entry existed
+   */
+  remove(id: string): Promise<boolean>
+}

--- a/packages/schema/context/system.ts
+++ b/packages/schema/context/system.ts
@@ -1,0 +1,57 @@
+/**
+ * System Context
+ *
+ * @experimental No real implementation yet.
+ *
+ * Read-only view of all system state for the context
+ * phase of the agent loop. Pure composition — each
+ * system API owns its own Context interface.
+ * Write operations live in actions/system.ts.
+ */
+
+import type { EnvContext } from '../system/env'
+import type { SettingsContext } from '../system/settings'
+import type { PreferencesContext } from '../system/preferences'
+import type { RegistryContext } from '../system/registry'
+import type { FsContext } from '../system/fs'
+import type { SandboxContext } from '../system/sandbox'
+import type { InstallerContext } from '../system/installer'
+import type { McpContext } from '../system/mcp-client'
+
+export type {
+  EnvContext,
+  SettingsContext,
+  PreferencesContext,
+  RegistryContext,
+  FsContext,
+  SandboxContext,
+  InstallerContext,
+  McpContext,
+}
+
+/**
+ * Read-only system context interface
+ *
+ * Composes all system read interfaces into a single
+ * entry point for the context phase of the agent loop.
+ * Enforces zero-trust by limiting the agent to
+ * observation, not mutation.
+ */
+export interface SystemContext {
+  /** Environment variables */
+  env: EnvContext
+  /** System-wide settings */
+  settings: SettingsContext
+  /** Scoped preferences */
+  preferences: PreferencesContext
+  /** Resource registries */
+  registry: RegistryContext
+  /** Host filesystem */
+  fs: FsContext
+  /** Sandbox environments */
+  sandbox: SandboxContext
+  /** Installed packages */
+  installer: InstallerContext
+  /** MCP server connections */
+  mcp: McpContext
+}

--- a/packages/schema/system/env.ts
+++ b/packages/schema/system/env.ts
@@ -1,0 +1,87 @@
+/**
+ * Environment Variables
+ *
+ * @experimental No real implementation yet.
+ *
+ * Platform-level management of environment variables.
+ * The kernel interface for creating, reading, updating,
+ * and removing configuration variables in the execution
+ * environment (Vercel, Cloudflare Workers, Railway).
+ */
+
+/**
+ * An environment variable entry
+ *
+ * @template T - The type of the variable value (typically string)
+ */
+export interface EnvEntry<T = string> {
+  /** Variable name */
+  key: string
+  /** Variable value */
+  value: T
+  /** Target environment(s) this variable applies to */
+  target?: string[]
+  /** Whether this variable contains sensitive data */
+  sensitive?: boolean
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Read-only environment context for the agent loop
+ */
+export interface EnvContext {
+  /** Get an environment variable */
+  get(key: string): Promise<EnvEntry | null>
+  /** List all environment variables (sensitive values may be masked) */
+  list(): Promise<EnvEntry[]>
+}
+
+/**
+ * Environment write operations for the agent loop
+ */
+export interface EnvActions {
+  /** Set an environment variable (create or update) */
+  set(entry: Omit<EnvEntry, 'metadata'>): Promise<EnvEntry>
+  /** Remove an environment variable */
+  remove(key: string): Promise<boolean>
+}
+
+/**
+ * Environment variable management interface
+ *
+ * Provides CRUD operations for platform environment variables.
+ * Implementations map to platform-specific APIs
+ * (e.g., Vercel REST API, Cloudflare Workers Secrets).
+ */
+export interface Env {
+  /**
+   * Get an environment variable
+   *
+   * @param key - Variable name
+   * @returns The entry, or null if not found
+   */
+  get(key: string): Promise<EnvEntry | null>
+
+  /**
+   * Set an environment variable (create or update)
+   *
+   * @param entry - The variable to set
+   */
+  set(entry: Omit<EnvEntry, 'metadata'>): Promise<EnvEntry>
+
+  /**
+   * Remove an environment variable
+   *
+   * @param key - Variable name
+   * @returns true if the variable existed
+   */
+  remove(key: string): Promise<boolean>
+
+  /**
+   * List all environment variables
+   *
+   * @returns Array of entries (sensitive values may be masked)
+   */
+  list(): Promise<EnvEntry[]>
+}

--- a/packages/schema/system/fs.ts
+++ b/packages/schema/system/fs.ts
@@ -1,0 +1,101 @@
+/**
+ * File System
+ *
+ * @experimental No real implementation yet.
+ *
+ * Platform-level file system operations.
+ * The kernel interface for reading, writing, and navigating
+ * files in the host execution environment (local disk, S3,
+ * Vercel Blob, Cloudflare R2). Sandbox environments
+ * manage their own internal filesystem independently.
+ */
+
+/**
+ * A file system entry (file or directory)
+ */
+export interface FsEntry {
+  /** File or directory name */
+  name: string
+  /** Full path relative to the filesystem root */
+  path: string
+  /** Entry type */
+  type: 'file' | 'directory'
+  /** Size in bytes (files only) */
+  size?: number
+  /** Last modified timestamp (Unix ms) */
+  updatedAt?: number
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Read-only filesystem context for the agent loop
+ */
+export interface FsContext {
+  /** Read a file's contents */
+  read(path: string): Promise<string | null>
+  /** List entries in a directory */
+  list(path: string): Promise<FsEntry[]>
+  /** Check if a path exists */
+  exists(path: string): Promise<boolean>
+}
+
+/**
+ * Filesystem write operations for the agent loop
+ */
+export interface FsActions {
+  /** Write contents to a file (create or overwrite) */
+  write(path: string, content: string): Promise<FsEntry>
+  /** Delete a file or directory */
+  remove(path: string): Promise<boolean>
+}
+
+/**
+ * File system capability interface
+ *
+ * Provides CRUD operations for files and directories
+ * on the host platform. Implementations map to
+ * platform-specific filesystems (local disk, S3,
+ * Vercel Blob, Cloudflare R2).
+ */
+export interface Fs {
+  /**
+   * Read a file's contents
+   *
+   * @param path - File path
+   * @returns File contents as string, or null if not found
+   */
+  read(path: string): Promise<string | null>
+
+  /**
+   * Write contents to a file (create or overwrite)
+   *
+   * @param path - File path
+   * @param content - File contents
+   * @returns The created or updated entry
+   */
+  write(path: string, content: string): Promise<FsEntry>
+
+  /**
+   * Delete a file or directory
+   *
+   * @param path - File or directory path
+   * @returns true if the entry existed
+   */
+  remove(path: string): Promise<boolean>
+
+  /**
+   * List entries in a directory
+   *
+   * @param path - Directory path
+   * @returns Array of entries in the directory
+   */
+  list(path: string): Promise<FsEntry[]>
+
+  /**
+   * Check if a path exists
+   *
+   * @param path - File or directory path
+   */
+  exists(path: string): Promise<boolean>
+}

--- a/packages/schema/system/installer.ts
+++ b/packages/schema/system/installer.ts
@@ -1,0 +1,104 @@
+/**
+ * Installer
+ *
+ * @experimental No real implementation yet.
+ *
+ * Installation and management of skills, tools, and
+ * extensions. The kernel's package manager for adding
+ * capabilities to the system at runtime
+ * (npm, pip, Claude Code Skills, Homebrew).
+ */
+
+/**
+ * Installation status
+ */
+export type InstallStatus = 'installed' | 'updating' | 'failed'
+
+/**
+ * An installed package entry
+ */
+export interface InstallEntry {
+  /** Package identifier */
+  name: string
+  /** Installed version */
+  version: string
+  /** Current status */
+  status: InstallStatus
+  /** When this package was installed (Unix ms) */
+  installedAt: number
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Read-only installer context for the agent loop
+ */
+export interface InstallerContext {
+  /** Get an installed package by name */
+  get(name: string): Promise<InstallEntry | null>
+  /** List all installed packages */
+  list(): Promise<InstallEntry[]>
+}
+
+/**
+ * Installer write operations for the agent loop
+ */
+export interface InstallerActions {
+  /** Install a package */
+  install(name: string, version?: string): Promise<InstallEntry>
+  /** Uninstall a package */
+  uninstall(name: string): Promise<boolean>
+  /** Update a package to a specific or latest version */
+  update(name: string, version?: string): Promise<InstallEntry>
+}
+
+/**
+ * Package installer management interface
+ *
+ * Provides lifecycle management for installable
+ * capabilities (skills, tools, extensions).
+ * Implementations map to platform-specific package
+ * managers and registries.
+ */
+export interface Installer {
+  /**
+   * Install a package
+   *
+   * @param name - Package identifier
+   * @param version - Version to install (optional, defaults to latest)
+   * @returns The installed entry
+   */
+  install(name: string, version?: string): Promise<InstallEntry>
+
+  /**
+   * Uninstall a package
+   *
+   * @param name - Package identifier
+   * @returns true if the package was installed
+   */
+  uninstall(name: string): Promise<boolean>
+
+  /**
+   * Get an installed package by name
+   *
+   * @param name - Package identifier
+   * @returns The install entry, or null if not installed
+   */
+  get(name: string): Promise<InstallEntry | null>
+
+  /**
+   * List all installed packages
+   *
+   * @returns Array of all installed entries
+   */
+  list(): Promise<InstallEntry[]>
+
+  /**
+   * Update a package to a specific or latest version
+   *
+   * @param name - Package identifier
+   * @param version - Version to update to (optional, defaults to latest)
+   * @returns The updated entry
+   */
+  update(name: string, version?: string): Promise<InstallEntry>
+}

--- a/packages/schema/system/mcp-client.ts
+++ b/packages/schema/system/mcp-client.ts
@@ -1,0 +1,94 @@
+/**
+ * MCP Client
+ *
+ * @experimental No real implementation yet.
+ *
+ * Platform-level MCP (Model Context Protocol) client.
+ * The kernel interface for connecting to and managing
+ * external MCP servers that provide tools, resources,
+ * and prompts to the system (Claude Code MCP, Cursor
+ * MCP, VS Code Copilot MCP).
+ */
+
+/**
+ * MCP server connection status
+ */
+export type McpServerStatus = 'connected' | 'disconnected' | 'error'
+
+/**
+ * An MCP server connection entry
+ */
+export interface McpServerEntry {
+  /** Unique identifier for this connection */
+  name: string
+  /** Server transport URI (stdio, SSE, streamable HTTP) */
+  uri: string
+  /** Current connection status */
+  status: McpServerStatus
+  /** Tools exposed by this server */
+  tools?: string[]
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Read-only MCP client context for the agent loop
+ */
+export interface McpContext {
+  /** Get an MCP server connection by name */
+  get(name: string): Promise<McpServerEntry | null>
+  /** List all MCP server connections */
+  list(): Promise<McpServerEntry[]>
+}
+
+/**
+ * MCP client write operations for the agent loop
+ */
+export interface McpActions {
+  /** Connect to an MCP server */
+  connect(name: string, uri: string): Promise<McpServerEntry>
+  /** Disconnect from an MCP server */
+  disconnect(name: string): Promise<boolean>
+}
+
+/**
+ * MCP client management interface
+ *
+ * Provides infrastructure-level management of MCP server
+ * connections. This is the kernel's device driver manager —
+ * it connects to external capability providers. The agent-facing
+ * side lives in actions/mcp-servers.ts.
+ */
+export interface McpClient {
+  /**
+   * Connect to an MCP server
+   *
+   * @param name - Connection identifier
+   * @param uri - Server transport URI
+   * @returns The connection entry
+   */
+  connect(name: string, uri: string): Promise<McpServerEntry>
+
+  /**
+   * Disconnect from an MCP server
+   *
+   * @param name - Connection identifier
+   * @returns true if the connection existed
+   */
+  disconnect(name: string): Promise<boolean>
+
+  /**
+   * Get a connection by name
+   *
+   * @param name - Connection identifier
+   * @returns The connection entry, or null if not found
+   */
+  get(name: string): Promise<McpServerEntry | null>
+
+  /**
+   * List all MCP server connections
+   *
+   * @returns Array of all connection entries
+   */
+  list(): Promise<McpServerEntry[]>
+}

--- a/packages/schema/system/preferences.ts
+++ b/packages/schema/system/preferences.ts
@@ -1,0 +1,102 @@
+/**
+ * Agent Preferences
+ *
+ * @experimental No real implementation yet.
+ *
+ * Per-agent or per-user preference storage.
+ * The kernel interface for managing scoped configuration
+ * that customizes agent behavior without affecting
+ * the global system (VS Code Settings, Claude Code
+ * Scoped Config, GitHub User Preferences).
+ */
+
+/**
+ * Preference scope
+ *
+ * Resolution cascades: agent > user > system.
+ * The 'system' scope is a passthrough to system settings.
+ */
+export type PreferenceScope = 'agent' | 'user' | 'system'
+
+/**
+ * A preference entry
+ *
+ * @template T - The type of the preference value
+ */
+export interface PreferenceEntry<T = unknown> {
+  /** Preference key */
+  key: string
+  /** Preference value */
+  value: T
+  /** Scope this preference applies to */
+  scope: PreferenceScope
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Read-only preferences context for the agent loop
+ */
+export interface PreferencesContext {
+  /** Get a preference by key and scope */
+  get<T = unknown>(key: string, scope: PreferenceScope): Promise<PreferenceEntry<T> | null>
+  /** List all preferences for a given scope */
+  list(scope: PreferenceScope): Promise<PreferenceEntry[]>
+}
+
+/**
+ * Preferences write operations for the agent loop
+ */
+export interface PreferencesActions {
+  /** Set a preference value (create or update) */
+  set<T = unknown>(key: string, value: T, scope: PreferenceScope): Promise<PreferenceEntry<T>>
+  /** Remove a preference */
+  remove(key: string, scope: PreferenceScope): Promise<boolean>
+}
+
+/**
+ * Agent preferences management interface
+ *
+ * Provides scoped CRUD operations for per-agent and
+ * per-user configuration. For system-wide settings,
+ * see settings.ts.
+ */
+export interface Preferences {
+  /**
+   * Get a preference by key and scope
+   *
+   * @template T - The type of the preference value
+   * @param key - Preference key
+   * @param scope - Preference scope
+   * @returns The preference entry, or null if not found
+   */
+  get<T = unknown>(key: string, scope: PreferenceScope): Promise<PreferenceEntry<T> | null>
+
+  /**
+   * Set a preference value (create or update)
+   *
+   * @template T - The type of the preference value
+   * @param key - Preference key
+   * @param value - Preference value
+   * @param scope - Preference scope
+   * @returns The created or updated entry
+   */
+  set<T = unknown>(key: string, value: T, scope: PreferenceScope): Promise<PreferenceEntry<T>>
+
+  /**
+   * Remove a preference
+   *
+   * @param key - Preference key
+   * @param scope - Preference scope
+   * @returns true if the preference existed
+   */
+  remove(key: string, scope: PreferenceScope): Promise<boolean>
+
+  /**
+   * List all preferences for a given scope
+   *
+   * @param scope - Preference scope
+   * @returns Array of preference entries
+   */
+  list(scope: PreferenceScope): Promise<PreferenceEntry[]>
+}

--- a/packages/schema/system/registry.ts
+++ b/packages/schema/system/registry.ts
@@ -1,0 +1,97 @@
+/**
+ * Registry
+ *
+ * @experimental No real implementation yet.
+ *
+ * Registration and discovery of resources in the system.
+ * The kernel interface for managing what is available
+ * and finding it by criteria. Providers extend this
+ * for specific resource types (agents, skills, MCP servers).
+ * (Google A2A Agent Cards, Microsoft AutoGen Registry,
+ * AGENTS.md/AAIF Agent Discovery, npm Registry).
+ */
+
+/**
+ * A registry entry
+ *
+ * @template T - The type of the registered resource
+ */
+export interface RegistryEntry<T = unknown> {
+  /** Unique identifier */
+  name: string
+  /** Human-readable description */
+  description: string
+  /** The registered resource */
+  resource: T
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Read-only registry context for the agent loop
+ */
+export interface RegistryContext {
+  /** Get a resource from a named registry */
+  get<T = unknown>(registry: string, name: string): Promise<RegistryEntry<T> | null>
+  /** List all resources in a named registry */
+  list<T = unknown>(registry: string): Promise<RegistryEntry<T>[]>
+}
+
+/**
+ * Registry write operations for the agent loop
+ */
+export interface RegistryActions {
+  /** Register a resource in a named registry */
+  register<T = unknown>(registry: string, entry: RegistryEntry<T>): Promise<void>
+  /** Unregister a resource from a named registry */
+  unregister(registry: string, name: string): Promise<boolean>
+}
+
+/**
+ * Resource registry management interface
+ *
+ * Provides registration, discovery, and lookup for
+ * any type of system resource. Providers implement
+ * this with specific resource types.
+ *
+ * @template T - The type of the registered resource
+ */
+export interface Registry<T = unknown> {
+  /**
+   * Register a resource
+   *
+   * @param entry - Registry entry
+   */
+  register(entry: RegistryEntry<T>): Promise<void>
+
+  /**
+   * Unregister a resource
+   *
+   * @param name - Resource name
+   * @returns true if the resource was registered
+   */
+  unregister(name: string): Promise<boolean>
+
+  /**
+   * Get a resource by name
+   *
+   * @param name - Resource name
+   * @returns The registry entry, or null if not found
+   */
+  get(name: string): Promise<RegistryEntry<T> | null>
+
+  /**
+   * List all registered resources
+   *
+   * @returns Array of all registry entries
+   */
+  list(): Promise<RegistryEntry<T>[]>
+
+  /**
+   * Find resources matching criteria
+   *
+   * @param criteria - Partial match against resource fields
+   * @returns Array of matching registry entries
+   */
+  find(criteria: Partial<T>): Promise<RegistryEntry<T>[]>
+}

--- a/packages/schema/system/sandbox.ts
+++ b/packages/schema/system/sandbox.ts
@@ -1,0 +1,191 @@
+/**
+ * Sandbox
+ *
+ * @experimental No real implementation yet.
+ *
+ * Isolated execution environments for running agent workloads.
+ * The kernel interface for creating, managing, and interacting
+ * with sandboxed environments (Vercel Sandbox, E2B,
+ * Cloudflare Workers, Docker).
+ */
+
+/**
+ * Sandbox status lifecycle
+ */
+export type SandboxStatus =
+  | 'pending'
+  | 'running'
+  | 'stopping'
+  | 'stopped'
+  | 'failed'
+
+/**
+ * Sandbox summary for listing
+ */
+export interface SandboxEntry {
+  /** Unique sandbox identifier */
+  id: string
+  /** Current lifecycle status */
+  status: SandboxStatus
+  /** When the sandbox was created (Unix ms) */
+  createdAt: number
+  /** Remaining time before auto-stop (ms) */
+  timeout?: number
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Configuration for creating a new sandbox
+ */
+export interface SandboxConfig {
+  /** Runtime or template identifier (e.g., "node24", "python3.13") */
+  runtime?: string
+  /** Initial timeout in milliseconds before auto-stop */
+  timeout?: number
+  /** Environment variables to inject */
+  env?: Record<string, string>
+  /** Ports to expose for external access */
+  ports?: number[]
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Result of a command execution
+ */
+export interface CommandResult {
+  /** Process exit code (0 = success) */
+  exitCode: number
+  /** Standard output */
+  stdout: string
+  /** Standard error */
+  stderr: string
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * A file within the sandbox filesystem
+ */
+export interface SandboxFile {
+  /** File path within the sandbox */
+  path: string
+  /** File contents */
+  content: string
+}
+
+/**
+ * Read-only sandbox context for the agent loop
+ */
+export interface SandboxContext {
+  /** Get an existing sandbox by ID */
+  get(id: string): Promise<SandboxEntry | null>
+  /** List all sandboxes */
+  list(): Promise<SandboxEntry[]>
+}
+
+/**
+ * Sandbox write operations for the agent loop
+ */
+export interface SandboxActions {
+  /** Create a new sandbox */
+  create(config?: SandboxConfig): Promise<SandboxEntry>
+  /** Stop and destroy a sandbox */
+  stop(id: string): Promise<boolean>
+  /** Execute a command inside a sandbox */
+  exec(id: string, command: string, args?: string[]): Promise<CommandResult>
+  /** Write files to the sandbox filesystem */
+  writeFiles(id: string, files: SandboxFile[]): Promise<void>
+  /** Read a file from the sandbox filesystem */
+  readFile(id: string, path: string): Promise<string | null>
+  /** Get a publicly accessible URL for an exposed port */
+  getUrl(id: string, port: number): Promise<string | null>
+  /** Extend the sandbox timeout */
+  extendTimeout(id: string, duration: number): Promise<void>
+}
+
+/**
+ * Sandbox management interface
+ *
+ * Provides lifecycle management for isolated execution
+ * environments. Each sandbox has its own filesystem,
+ * command execution, and optional network access.
+ * Implementations map to provider-specific sandbox APIs.
+ */
+export interface Sandbox {
+  /**
+   * Create a new sandbox
+   *
+   * @param config - Sandbox configuration
+   * @returns The created sandbox entry
+   */
+  create(config?: SandboxConfig): Promise<SandboxEntry>
+
+  /**
+   * Get an existing sandbox by ID
+   *
+   * @param id - Sandbox identifier
+   * @returns The sandbox entry, or null if not found
+   */
+  get(id: string): Promise<SandboxEntry | null>
+
+  /**
+   * List all sandboxes
+   *
+   * @returns Array of sandbox entries
+   */
+  list(): Promise<SandboxEntry[]>
+
+  /**
+   * Stop and destroy a sandbox
+   *
+   * @param id - Sandbox identifier
+   * @returns true if the sandbox existed
+   */
+  stop(id: string): Promise<boolean>
+
+  /**
+   * Execute a command inside a sandbox
+   *
+   * @param id - Sandbox identifier
+   * @param command - Command to execute
+   * @param args - Command arguments
+   * @returns The command result with exit code and output
+   */
+  exec(id: string, command: string, args?: string[]): Promise<CommandResult>
+
+  /**
+   * Read a file from the sandbox filesystem
+   *
+   * @param id - Sandbox identifier
+   * @param path - File path within the sandbox
+   * @returns File contents, or null if not found
+   */
+  readFile(id: string, path: string): Promise<string | null>
+
+  /**
+   * Write files to the sandbox filesystem
+   *
+   * @param id - Sandbox identifier
+   * @param files - Files to write
+   */
+  writeFiles(id: string, files: SandboxFile[]): Promise<void>
+
+  /**
+   * Get a publicly accessible URL for an exposed port
+   *
+   * @param id - Sandbox identifier
+   * @param port - Port number
+   * @returns The public URL, or null if the port is not exposed
+   */
+  getUrl(id: string, port: number): Promise<string | null>
+
+  /**
+   * Extend the sandbox timeout
+   *
+   * @param id - Sandbox identifier
+   * @param duration - Additional time in milliseconds
+   */
+  extendTimeout(id: string, duration: number): Promise<void>
+}

--- a/packages/schema/system/settings.ts
+++ b/packages/schema/system/settings.ts
@@ -1,0 +1,92 @@
+/**
+ * System Settings
+ *
+ * @experimental No real implementation yet.
+ *
+ * Global configuration that affects platform behavior.
+ * The kernel interface for managing system-wide settings
+ * that apply to all agents and workflows
+ * (Vercel Project Settings, Cloudflare Zone Settings,
+ * AWS SSM Parameter Store).
+ */
+
+/**
+ * A system setting entry
+ *
+ * @template T - The type of the setting value
+ */
+export interface SettingsEntry<T = unknown> {
+  /** Setting key */
+  key: string
+  /** Setting value */
+  value: T
+  /** Human-readable description */
+  description?: string
+  /** Whether this setting is read-only (cannot be changed at runtime) */
+  readOnly?: boolean
+  /** Extensible metadata for provider-specific data */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Read-only settings context for the agent loop
+ */
+export interface SettingsContext {
+  /** Get a system setting */
+  get<T = unknown>(key: string): Promise<SettingsEntry<T> | null>
+  /** List all settings */
+  list(): Promise<SettingsEntry[]>
+}
+
+/**
+ * Settings write operations for the agent loop
+ */
+export interface SettingsActions {
+  /** Set a setting value (create or update) */
+  set<T = unknown>(key: string, value: T): Promise<SettingsEntry<T>>
+  /** Remove a setting (revert to default) */
+  remove(key: string): Promise<boolean>
+}
+
+/**
+ * System settings management interface
+ *
+ * Provides CRUD operations for global platform settings.
+ * Settings are system-wide — for per-agent configuration,
+ * see preferences.ts.
+ */
+export interface Settings {
+  /**
+   * Get a setting by key
+   *
+   * @template T - The type of the setting value
+   * @param key - Setting key
+   * @returns The setting entry, or null if not found
+   */
+  get<T = unknown>(key: string): Promise<SettingsEntry<T> | null>
+
+  /**
+   * Set a setting value (create or update)
+   *
+   * @template T - The type of the setting value
+   * @param key - Setting key
+   * @param value - Setting value
+   * @returns The created or updated entry
+   */
+  set<T = unknown>(key: string, value: T): Promise<SettingsEntry<T>>
+
+  /**
+   * Remove a setting (revert to default)
+   *
+   * @param key - Setting key
+   * @returns true if the setting existed
+   */
+  remove(key: string): Promise<boolean>
+
+  /**
+   * List all settings
+   *
+   * @returns Array of all setting entries
+   */
+  list(): Promise<SettingsEntry[]>
+}


### PR DESCRIPTION
## Summary

All 19 Extension interface drafts from issue #38 completed. 18 files changed: 17 interfaces written, 2 new files created (sandbox.ts, actions/system.ts), 2 interfaces eliminated (documents.ts absorbed into embeddings, memory.ts overlapped with storage + embeddings).

**1,725 lines added** — all `@experimental`, all typecheck passing.

### What changed

**System (8 files)** — each owns its own `*Context` (read) and `*Actions` (write) interfaces:
- `env.ts` — CRUD for platform env vars
- `fs.ts` — Host filesystem operations
- `sandbox.ts` — **NEW** isolated execution environments
- `settings.ts` — Global system configuration
- `preferences.ts` — Scoped per-agent/user preferences
- `registry.ts` — Generic `Registry<T>`
- `mcp-client.ts` — Infrastructure MCP management
- `installer.ts` — Package management

**Context (2 files)**:
- `embeddings.ts` — Vector embeddings + similarity search (also absorbs documents)
- `system.ts` — Read-only composition facade

**Actions (3 files)**:
- `tools.ts` — Tool discovery and execution
- `mcp-servers.ts` — Agent-facing MCP (resources + prompts)
- `system.ts` — **NEW** write composition facade

**Checks (4 files)**:
- `rules.ts` — Declarative verification criteria
- `judge.ts` — LLM-as-judge evaluation
- `audit.ts` — Immutable audit trail
- `screenshot.ts` — Visual capture and comparison

**Apps (1 file)**:
- `schema.ts` — Distribution manifest (.md with YAML frontmatter)

### Architectural decisions

- CRUD as default interface shape
- Provider-extensible metadata on entries (not services)
- Each system API owns its Context + Actions interfaces
- Facades are pure composition (no logic)
- `@experimental` tag on all new interfaces
- Generic `Registry<T>` compatible with A2A discovery

### Cross-referenced providers

Vercel, Cloudflare, AWS, Pinecone, Upstash, Sentry, OpenTelemetry, Datadog, Playwright, Puppeteer, Browserbase, ScreenshotOne, Braintrust, OpenAI Evals

### Deferred

- `ops/` domain (tracing, errors, metrics) — separate epic with research in `ops.md`

Closes #38