### PR TITLE
SEO: sitemap, robots, canonical URLs, metadata improvements, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,67 @@
 
 <p align="center">
   <a href="https://osprotocol.dev/docs">Documentation</a> |
-  <a href="https://osprotocol.dev/docs/architecture">Architecture</a>
+  <a href="https://osprotocol.dev/docs/architecture">Architecture</a> |
+  <a href="https://www.npmjs.com/package/@osprotocol/schema">npm</a>
 </p>
 
+#### About
 
-#### About 
+The OS Protocol is an open-source specification for orchestrating, managing, and executing AI agents in distributed environments. It defines standardized interfaces across six domains:
 
-The OS Protocol is an open source project mantained by [@synerops](https://github.com/synerops) and open to contributions from the entire community.
+- **System** — registry, environment, filesystem, sandbox, settings, preferences, installer, MCP client
+- **Context** — read-only facades (system context, embeddings, key-value)
+- **Actions** — write facades (system actions, tools, MCP servers)
+- **Checks** — quality assurance (rules, judge, audit, screenshot)
+- **Workflows** — execution patterns (routing, parallelization, orchestrator-workers, evaluator-optimizer)
+- **Runs** — lifecycle control (timeout, retry, cancel, approval)
+
+#### Project Structure
+
+```
+osprotocol/
+├── apps/web/           # Documentation site (Next.js + Fumadocs)
+│   ├── content/docs/   # MDX documentation pages
+│   └── app/            # App Router pages and API routes
+└── packages/schema/    # @osprotocol/schema (TypeScript types)
+    ├── system/         # System domain interfaces
+    ├── context/        # Context domain interfaces
+    ├── actions/        # Actions domain interfaces
+    ├── checks/         # Checks domain interfaces
+    ├── workflows/      # Workflow pattern types
+    ├── runs/           # Run control types
+    └── apps/           # App distribution manifest types
+```
+
+#### Quick Start
+
+```bash
+bun install            # Install dependencies
+bun run dev            # Start dev server
+bun run build          # Build all packages
+bun run typecheck      # Type check all packages
+```
+
+#### Skills (Claude Code)
+
+This project includes skills for local development with [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview):
+
+| Skill | Description |
+|-------|-------------|
+| `/ask` | Answer questions about the protocol — architecture, concepts, rationale, interfaces, domains, and design principles. |
+| `/docs` | Write, edit, review, and triage documentation pages for the website. |
+
+Skills are defined in `.claude/skills/` and provide domain-specific context so the agent can work accurately with the protocol.
+
+#### LLM-Friendly Endpoints
+
+The documentation site exposes machine-readable endpoints for LLM tools and agents:
+
+| Endpoint | Description |
+|----------|-------------|
+| [`/llms.txt`](https://osprotocol.dev/llms.txt) | Documentation index — page titles, descriptions, and links grouped by section. |
+| [`/llms-full.txt`](https://osprotocol.dev/llms-full.txt) | Full documentation content — complete markdown text of every page. |
+
+#### About
+
+Maintained by [@synerops](https://github.com/synerops) and open to contributions from the community.

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -11,6 +11,9 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 
   return createMetadata({
+    alternates: {
+      canonical: 'https://osprotocol.dev',
+    },
     openGraph: {
       url: '/',
       images: [image],

--- a/apps/web/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/docs/[[...slug]]/page.tsx
@@ -115,6 +115,9 @@ export async function generateMetadata(props: PageProps<'/docs/[[...slug]]'>): P
   return createMetadata({
     title: page.data.title,
     description: page.data.description || siteConfig.description,
+    alternates: {
+      canonical: `https://osprotocol.dev/docs/${page.slugs.join('/')}`,
+    },
     openGraph: {
       url: `https://osprotocol.dev/docs/${page.slugs.join('/')}`,
       images: [image],

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from 'next';
+import { baseUrl } from '@/lib/metadata';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: new URL('/sitemap.xml', baseUrl).toString(),
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from 'next';
+import { baseUrl } from '@/lib/metadata';
+import { source } from '@/lib/source';
+
+export const revalidate = false;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const url = (path: string): string => new URL(path, baseUrl).toString();
+
+  const pages = source.getPages().map((page) => ({
+    url: url(page.url),
+    changeFrequency: 'weekly' as const,
+    priority: 0.5,
+  }));
+
+  return [
+    {
+      url: url('/'),
+      changeFrequency: 'monthly',
+      priority: 1.0,
+    },
+    {
+      url: url('/docs'),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    ...pages,
+  ];
+}

--- a/apps/web/content/docs/actions/mcp-servers.mdx
+++ b/apps/web/content/docs/actions/mcp-servers.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Servers
-description: Agent-facing interface for accessing MCP server resources and prompts.
+description: "MCP Servers interface — discover, connect, and invoke tools from external Model Context Protocol servers within agent workflows."
 ---
 
 <Callout type="warn">

--- a/apps/web/content/docs/actions/system.mdx
+++ b/apps/web/content/docs/actions/system.mdx
@@ -1,6 +1,6 @@
 ---
 title: System Actions
-description: Write operations facade for all system interfaces during the actions phase
+description: "System actions — aggregated write operations facade for filesystem, settings, and environment changes during the agent loop's action phase."
 ---
 
 <Callout type="warn">

--- a/apps/web/content/docs/architecture.mdx
+++ b/apps/web/content/docs/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: High-level architecture of the Agentic OS Protocol
+description: "Architecture overview of the Agentic OS Protocol — six domains, the agent loop, workflow patterns, and how they compose into a system."
 ---
 
 ## Overview

--- a/apps/web/content/docs/checks/judge.mdx
+++ b/apps/web/content/docs/checks/judge.mdx
@@ -1,6 +1,6 @@
 ---
 title: Judge
-description: LLM-as-judge evaluation for scoring agent output against quality criteria
+description: "LLM-as-judge evaluation — score agent output against quality criteria using configurable models, rubrics, and pass/fail thresholds."
 ---
 
 <Callout type="warn">

--- a/apps/web/content/docs/concepts/agent-loop.mdx
+++ b/apps/web/content/docs/concepts/agent-loop.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Loop
-description: The core execution pattern for AI agents
+description: "The agent loop — gather context, take actions, verify results. The core cognitive cycle that drives every AI agent in the protocol."
 ---
 
 ## Overview

--- a/apps/web/content/docs/concepts/agentic-os.mdx
+++ b/apps/web/content/docs/concepts/agentic-os.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agentic OS
-description: The architectural metaphor that defines how AI systems manage agent resources
+description: "The Agentic OS concept — an operating system metaphor where LLMs function as the kernel, managing agent resources through standardized APIs."
 ---
 
 ## Overview

--- a/apps/web/content/docs/concepts/lifecycle.mdx
+++ b/apps/web/content/docs/concepts/lifecycle.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Lifecycle
-description: System-level agent management workflow
+description: "Agent lifecycle management — registration, discovery, execution, and evaluation. How the system manages agents from creation to retirement."
 ---
 
 ## Overview

--- a/apps/web/content/docs/concepts/workflows-taxonomy.mdx
+++ b/apps/web/content/docs/concepts/workflows-taxonomy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Workflows Taxonomy
-description: Understanding the six categories of workflow patterns
+description: "Taxonomy of workflow patterns for AI agents — task, quality, and recovery workflows. Based on Anthropic's building blocks for agentic systems."
 ---
 
 ## Overview

--- a/apps/web/content/docs/context/embeddings.mdx
+++ b/apps/web/content/docs/context/embeddings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Embeddings
-description: Vector similarity search and semantic indexing for agents
+description: "Embeddings interface for AI agents — vector similarity search, semantic indexing, and namespace-scoped collections for RAG and retrieval."
 ---
 
 <Callout type="warn">

--- a/apps/web/content/docs/context/index.mdx
+++ b/apps/web/content/docs/context/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Context
-description: Application-specific context and data management
+description: "Context domain — read-only facades for the agent loop's gather phase. System state, embeddings, and key-value storage for AI agents."
 ---
 
 ## Overview

--- a/apps/web/content/docs/context/kv.mdx
+++ b/apps/web/content/docs/context/kv.mdx
@@ -1,6 +1,6 @@
 ---
 title: Key-Value Store
-description: Flat key-value persistence for structured agent data
+description: "Key-value store for AI agents — flat, namespace-scoped persistence for structured data with TTL support and typed get/set/delete operations."
 ---
 
 <Callout type="warn">

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: An overview of the Agentic OS Protocol
+description: "Open specification for orchestrating AI agents at scale — standardized interfaces for system, context, actions, checks, workflows, and runs."
 ---
 import { Orbit, Boxes, CircuitBoard, Server } from 'lucide-react';
 

--- a/apps/web/content/docs/motivation.mdx
+++ b/apps/web/content/docs/motivation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Motivation
-description: Why the Agentic OS Protocol exists and what problems it solves
+description: "Why the Agentic OS Protocol exists — the interoperability, coordination, and quality problems it solves for multi-agent systems."
 ---
 
 ## The Challenge

--- a/apps/web/content/docs/runs/approval.mdx
+++ b/apps/web/content/docs/runs/approval.mdx
@@ -1,6 +1,6 @@
 ---
 title: Approval
-description: Human-in-the-loop approval for workflow execution
+description: "Human-in-the-loop approval gates — pause AI agent execution for review, with configurable timeouts, escalation, and multi-approver support."
 ---
 
 ## Overview

--- a/apps/web/content/docs/runs/cancel.mdx
+++ b/apps/web/content/docs/runs/cancel.mdx
@@ -1,6 +1,6 @@
 ---
-title: Cancel
-description: Workflow cancellation mechanisms
+title: Cancellation
+description: "Workflow cancellation for AI agents — graceful abort with cleanup callbacks, partial result preservation, and cascading child run cancellation."
 ---
 
 ## Overview

--- a/apps/web/content/docs/runs/retry.mdx
+++ b/apps/web/content/docs/runs/retry.mdx
@@ -1,6 +1,6 @@
 ---
 title: Retry
-description: Retry mechanisms for failed operations
+description: "Retry mechanisms for AI agent workflows — configurable strategies with backoff, max attempts, and error filtering for failed operations."
 ---
 
 ## Overview

--- a/apps/web/content/docs/runs/run.mdx
+++ b/apps/web/content/docs/runs/run.mdx
@@ -1,6 +1,6 @@
 ---
-title: Run
-description: Workflow runs and execution lifecycle
+title: Run Lifecycle
+description: "Run lifecycle — states, transitions, and execution tracking for AI agent workflow runs. The core unit of observable work in the protocol."
 ---
 
 ## Overview

--- a/apps/web/content/docs/runs/timeout.mdx
+++ b/apps/web/content/docs/runs/timeout.mdx
@@ -1,6 +1,6 @@
 ---
 title: Timeout
-description: Timeout management for workflow execution
+description: "Timeout control for AI agent workflows — set execution time limits with configurable strategies for graceful shutdown and cleanup."
 ---
 
 ## Overview

--- a/apps/web/content/docs/system/env.mdx
+++ b/apps/web/content/docs/system/env.mdx
@@ -1,6 +1,6 @@
 ---
 title: Environment
-description: Platform-level management of environment variables in the execution environment
+description: "Environment variable management for AI agents — read, write, list, and validate configuration in the host execution environment."
 ---
 
 <Callout type="warn">

--- a/apps/web/content/docs/system/index.mdx
+++ b/apps/web/content/docs/system/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: System
 description: Infrastructure services that provide system-level intelligence for agent orchestration
 ---
 import { Database, Settings as SettingsIcon, FolderOpen, Server, Wrench, User, Plug } from 'lucide-react';

--- a/apps/web/content/docs/system/sandbox.mdx
+++ b/apps/web/content/docs/system/sandbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sandbox
-description: Isolated execution environments for running agent workloads
+description: "Sandbox interface for AI agents — create isolated execution environments for running untrusted code with resource limits and lifecycle control."
 ---
 
 <Callout type="warn">

--- a/apps/web/content/docs/workflows/evaluator-optimizer.mdx
+++ b/apps/web/content/docs/workflows/evaluator-optimizer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Evaluator Optimizer
+title: Evaluator-Optimizer Workflow
 description: Iterative generate-evaluate-optimize loop that refines output until quality criteria are met.
 ---
 

--- a/apps/web/content/docs/workflows/index.mdx
+++ b/apps/web/content/docs/workflows/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Workflows
-description: Base workflow interface and execution patterns
+description: "Workflow patterns for AI agent coordination — routing, parallelization, orchestrator-workers, and evaluator-optimizer. Based on Anthropic's building blocks."
 ---
 
 ## Overview

--- a/apps/web/content/docs/workflows/orchestrator-worker.mdx
+++ b/apps/web/content/docs/workflows/orchestrator-worker.mdx
@@ -1,5 +1,5 @@
 ---
-title: Orchestrator-Workers
+title: Orchestrator-Workers Workflow
 description: Break complex tasks into a plan, delegate steps to specialized workers, and synthesize results into a final output.
 ---
 

--- a/apps/web/content/docs/workflows/parallelization.mdx
+++ b/apps/web/content/docs/workflows/parallelization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Parallelization
+title: Parallelization Workflow
 description: Split a task into independent subtasks, execute them concurrently, and merge the results.
 ---
 

--- a/apps/web/content/docs/workflows/routing.mdx
+++ b/apps/web/content/docs/workflows/routing.mdx
@@ -1,6 +1,6 @@
 ---
-title: Routing
-description: Classify an input and delegate execution to a single specialized workflow.
+title: Routing Workflow
+description: "Routing workflow — classify an input by intent or content type and delegate execution to a single specialized handler."
 ---
 
 <Callout type="warn">

--- a/apps/web/lib/metadata.ts
+++ b/apps/web/lib/metadata.ts
@@ -63,13 +63,13 @@ export function createBaseMetadata(): Metadata {
       title: siteConfig.name,
       description: siteConfig.description,
       siteName: siteConfig.name,
-      images: [],
+      images: [{ url: '/og', width: 1200, height: 630 }],
     },
     twitter: {
       card: 'summary_large_image',
       title: siteConfig.name,
       description: siteConfig.description,
-      images: [],
+      images: [{ url: '/og', width: 1200, height: 630 }],
       creator: siteConfig.twitterHandle,
     },
   };


### PR DESCRIPTION
## What

SEO infrastructure and metadata improvements for osprotocol.dev.

### Changes

**New files**
- `app/sitemap.ts` — dynamic sitemap from Fumadocs source (all doc pages)
- `app/robots.ts` — crawl directives + sitemap link

**Metadata**
- Add `alternates.canonical` to all doc pages and home page
- Fix base metadata empty `og:image` and `twitter:image` arrays (fallback to `/og`)

**Titles (7 changes)**
- `Introduction` (system/) → `System` (avoid duplicate with root Introduction)
- `Run` → `Run Lifecycle`
- `Cancel` → `Cancellation`
- 4 workflow pages: add `Workflow` suffix (Routing, Parallelization, Orchestrator-Workers, Evaluator-Optimizer)

**Descriptions (20 expansions)**
- Expanded from ~40-70 chars to ~120-155 chars with secondary keywords
- 18 descriptions already adequate, left unchanged

**README**
- Project structure, quick start commands
- Skills for local development (`/ask`, `/docs`)
- LLM-friendly endpoints (`/llms.txt`, `/llms-full.txt`)

### Build
Passes clean. `/sitemap.xml` and `/robots.txt` visible in build output.