### PR TITLE
fix: configure changesets for automatic releases

### DIFF
--- a/.changeset/fix-auto-release.md
+++ b/.changeset/fix-auto-release.md
@@ -1,0 +1,5 @@
+---
+"@osprotocol/schema": patch
+---
+
+Fix changesets workflow to automatically publish and create GitHub releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,20 +36,10 @@ jobs:
         uses: changesets/action@v1
         with:
           version: bun run version
+          publish: bun run release
           title: "chore: version packages"
           commit: "chore: version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to npm
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: |
-          cd packages/schema
-          LOCAL_VERSION=$(node -p "require('./package.json').version")
-          NPM_VERSION=$(npm view @osprotocol/schema version 2>/dev/null || echo "0.0.0")
-          if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
-            echo "Publishing @osprotocol/schema@$LOCAL_VERSION (npm has $NPM_VERSION)"
-            npm publish --provenance --access public
-          else
-            echo "Skipping publish: @osprotocol/schema@$LOCAL_VERSION already published"
-          fi
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "changeset publish"
+    "release": "bun run build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",


### PR DESCRIPTION
## Summary
- Configure changesets to automatically publish to npm and create GitHub releases
- Add `publish` and `createGithubReleases` to the changesets action
- Update release script to build before publishing

## Changes
- Updated `.github/workflows/release.yml` to use changesets publish properly
- Modified `package.json` release script to include build step
- Added changeset for this fix (will bump to v0.2.1)

## What will happen after merge
1. Changesets will create a "Version Packages" PR automatically
2. When that PR is merged, it will:
   - Publish to npm automatically
   - Create GitHub release with proper tag
   - Keep versions synchronized between npm and GitHub