### PR TITLE
chore: add changeset for audit ISO/ISACA alignment

### DIFF
--- a/.changeset/audit-iso-isaca.md
+++ b/.changeset/audit-iso-isaca.md
@@ -1,0 +1,10 @@
+---
+"@osprotocol/schema": patch
+---
+
+feat(checks): align AuditEntry with ISO 27001 / ISACA standards
+
+- Add `AuditOpinion` type for ISACA expression of opinion
+- Add `AuditFindings` for ISO 27001 severity counts  
+- Add `AuditQuery` for filtering entries
+- Update `Audit` interface with parse/write/query operations


### PR DESCRIPTION
Adds changeset for the audit interface changes merged in #57.

Will bump to `0.2.3` (patch).