### PR TITLE
feat: redesign home page with protocol domains

### DIFF
--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -32,6 +32,7 @@ const domains = [
     subtitle: 'System',
     description: 'What do agents need?',
     href: '/docs/system',
+    iconClass: 'icon-build',
   },
   {
     icon: RefreshCw,
@@ -39,6 +40,7 @@ const domains = [
     subtitle: 'Agent Loop',
     description: 'How do they think?',
     href: '/docs/concepts/agent-loop',
+    iconClass: 'icon-think',
   },
   {
     icon: Target,
@@ -46,6 +48,7 @@ const domains = [
     subtitle: 'Workflows',
     description: 'How do they work together?',
     href: '/docs/workflows',
+    iconClass: 'icon-focus',
   },
 ];
 
@@ -88,10 +91,10 @@ export default function HomePage() {
               href={domain.href}
               className="group flex flex-col items-center text-center p-6 rounded-lg border border-border/50 bg-background/50 backdrop-blur-sm hover:border-border hover:bg-background/70 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
-              <domain.icon className="w-8 h-8 mb-4 text-muted-foreground group-hover:text-foreground transition-colors" strokeWidth={1.5} aria-hidden="true" />
+              <domain.icon className={`w-8 h-8 mb-4 text-muted-foreground group-hover:text-foreground transition-colors ${domain.iconClass}`} strokeWidth={1.5} aria-hidden="true" />
               <h2 className="text-lg font-semibold text-foreground mb-0.5">{domain.title}</h2>
               <p className="text-xs text-muted-foreground/60 uppercase tracking-wider mb-3">{domain.subtitle}</p>
-              <p className="text-sm text-muted-foreground">{domain.description}</p>
+              <p className="text-sm text-muted-foreground italic">"{domain.description}"</p>
             </Link>
           ))}
         </div>
@@ -99,7 +102,7 @@ export default function HomePage() {
         {/* CTA */}
         <Link
           href="/docs"
-          className="inline-flex items-center justify-center px-6 py-2.5 text-sm font-medium border border-border rounded-md bg-transparent hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="inline-flex items-center justify-center px-6 py-2.5 text-sm font-medium border border-border rounded-md bg-transparent hover:bg-accent hover:text-accent-foreground transition-colors active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           View Documentation →
         </Link>

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { createMetadata, siteConfig } from '@/lib/metadata';
+import { Building, RefreshCw, Target } from 'lucide-react';
+import { createMetadata } from '@/lib/metadata';
 import WorldMap from '@/components/world-map';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -24,45 +25,86 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
+const domains = [
+  {
+    icon: Building,
+    title: 'Infrastructure',
+    subtitle: 'System',
+    description: 'What do agents need?',
+    href: '/docs/system',
+  },
+  {
+    icon: RefreshCw,
+    title: 'Autonomy',
+    subtitle: 'Agent Loop',
+    description: 'How do they think?',
+    href: '/docs/concepts/agent-loop',
+  },
+  {
+    icon: Target,
+    title: 'Orchestration',
+    subtitle: 'Workflows',
+    description: 'How do they work together?',
+    href: '/docs/workflows',
+  },
+];
+
 export default function HomePage() {
   return (
-    <div className="relative flex flex-col md:flex-row min-h-[calc(100vh-4rem)] md:min-h-screen w-full overflow-hidden">
+    <div className="relative flex flex-col min-h-[calc(100vh-4rem)] md:min-h-screen w-full overflow-hidden">
       <div className="absolute inset-0 z-0">
         <WorldMap />
         <div className="absolute inset-0 bg-linear-to-b from-background/95 via-background/85 to-background/98" />
       </div>
 
-      {/* Left side: Logo + Title */}
-      <div className="relative z-10 flex flex-col justify-center items-start px-8 md:px-16 lg:px-24 flex-1 py-12 md:py-0">
-        <div className="flex items-center gap-4">
-          <h1 className="text-4xl md:text-xl lg:text-5xl font-bold font-mono">The Agentic OS Protocol</h1>
+      <div className="relative z-10 flex flex-col justify-center items-center flex-1 px-8 py-16 md:py-24">
+        {/* Title + by SynerOps */}
+        <div className="text-center mb-8">
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold font-mono mb-3 text-balance">
+            The Agentic OS Protocol
+          </h1>
           <a
             href="https://synerops.com?utm_source=osp&utm_medium=website"
             target="_blank"
-            className="text-sm font-heading text-muted-foreground"
+            className="text-sm font-heading text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
             rel="noreferrer"
           >
             by SynerOps
           </a>
         </div>
-      </div>
 
-      {/* Vertical separator - hidden on mobile */}
-      <div className="hidden w-px bg-border relative z-10" />
-      {/* Horizontal separator - visible on mobile */}
-      <div className="md:hidden w-full h-px bg-border my-8 relative z-10" />
-
-      {/* Right side: Description + Link */}
-      <div className="relative z-10 flex flex-col justify-center items-start px-8 md:px-16 lg:px-24 flex-1 pb-12 md:pb-0">
-        <p className="text-lg md:text-xl text-muted-foreground max-w-md leading-relaxed mb-8">
-          The standard for <span className="text-primary">multi-agent systems</span>. Define agents, coordinate
-          workflows, and build systems where agents work together.
+        {/* Tagline */}
+        <p className="text-lg md:text-xl text-muted-foreground max-w-2xl text-center leading-relaxed mb-12 md:mb-16 text-balance">
+          A protocol that defines how agents communicate, coordinate, and solve problems together.
+          Like <span className="text-foreground">HTTP</span> for the web, or{' '}
+          <span className="text-foreground">REST</span> for APIs—but for AI agents.
         </p>
-        <Link href="/docs" className="text-sm text-muted-foreground hover:text-foreground transition-colors underline">
+
+        {/* Three Domains */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 w-full max-w-4xl mb-12 md:mb-16">
+          {domains.map((domain) => (
+            <Link
+              key={domain.title}
+              href={domain.href}
+              className="group flex flex-col items-center text-center p-6 rounded-lg border border-border/50 bg-background/50 backdrop-blur-sm hover:border-border hover:bg-background/70 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <domain.icon className="w-8 h-8 mb-4 text-muted-foreground group-hover:text-foreground transition-colors" strokeWidth={1.5} aria-hidden="true" />
+              <h2 className="text-lg font-semibold text-foreground mb-0.5">{domain.title}</h2>
+              <p className="text-xs text-muted-foreground/60 uppercase tracking-wider mb-3">{domain.subtitle}</p>
+              <p className="text-sm text-muted-foreground">{domain.description}</p>
+            </Link>
+          ))}
+        </div>
+
+        {/* CTA */}
+        <Link
+          href="/docs"
+          className="inline-flex items-center justify-center px-6 py-2.5 text-sm font-medium border border-border rounded-md bg-transparent hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
           View Documentation →
         </Link>
       </div>
     </div>
-  )
+  );
 }
 

--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -120,6 +120,28 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* Icon hover animations - semantic to each icon */
+.icon-build {
+  transition: transform 200ms ease-out;
+}
+.group:hover .icon-build {
+  transform: translateY(-2px);
+}
+
+.icon-think {
+  transition: transform 200ms ease-out;
+}
+.group:hover .icon-think {
+  transform: rotate(180deg);
+}
+
+.icon-focus {
+  transition: transform 200ms ease-out;
+}
+.group:hover .icon-focus {
+  transform: scale(0.85);
+}
+
 @layer base {
   /* * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary

- Redesigned home page with centered layout and clear visual hierarchy
- Added HTTP/REST analogy: "Like HTTP for the web, or REST for APIs—but for AI agents"
- 3 clickable domain cards (Infrastructure, Autonomy, Orchestration) linking to docs
- Semantic icon hover animations (build rises, think rotates, focus contracts)
- Accessibility: focus states, aria-hidden on decorative icons
- Typography: text-balance on headings, questions styled as prose

## Test plan

- [ ] Verify home page renders correctly on desktop and mobile
- [ ] Test card links navigate to correct docs sections
- [ ] Verify icon animations on hover
- [ ] Test keyboard navigation and focus states

🤖 Generated with [Claude Code](https://claude.com/claude-code)