### PR TITLE
chore: cleanup protocol types and improve agent instructions

### DIFF
--- a/.claude/agents/osprotocol-guide.md
+++ b/.claude/agents/osprotocol-guide.md
@@ -98,3 +98,4 @@ Orchestration patterns and lifecycle control based on Anthropic's Building Effec
 3. **Be precise.** Reference actual types, actual export paths, actual interface methods.
 4. **Acknowledge boundaries.** If something is `@experimental`, say so. If deferred, say it's not yet part of the protocol.
 5. **Keep it concise.** Match depth of answer to depth of question.
+6. **Accompany clarifying questions.** When asking for context, always provide examples that map to protocol concepts. Never ask bare questions or questions without enumerable answers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,3 @@ The `@osprotocol/schema` package provides TypeScript types for the protocol. See
 - Mermaid diagrams enabled via `remarkMdxMermaid` plugin
 - LLM-friendly endpoints at `/llms.txt` and `/llms-full.txt`
 
-### Protocol Concepts
-
-For questions about protocol architecture, concepts, design decisions, or domain boundaries, use the `osprotocol-guide` subagent. Do NOT answer conceptual questions from memory or from this file.
-
-**Quick reference** (for navigation only, not for answering conceptual questions):
-- 6 domains: System, Context, Actions, Checks, Workflows, Runs
-- Apps: Distribution manifests in `apps/schema.ts`

--- a/packages/schema/index.ts
+++ b/packages/schema/index.ts
@@ -7,36 +7,6 @@
  */
 
 // ---------------------------------------------------------------------------
-// Protocol taxonomy
-// ---------------------------------------------------------------------------
-
-/**
- * Protocol domain categories
- *
- * The protocol is organized into 4 categories (Q4):
- * - Agent Loop: context, actions, checks
- * - System: system
- * - Execution: workflows, runs
- */
-export type ProtocolDomain =
-  | 'system'
-  | 'context'
-  | 'actions'
-  | 'checks'
-  | 'workflows'
-  | 'runs'
-
-/**
- * Protocol reference (domain + API)
- */
-export interface ProtocolReference {
-  /** The protocol domain */
-  domain: ProtocolDomain
-  /** The API name within the domain */
-  api: string
-}
-
-// ---------------------------------------------------------------------------
 // Core domains
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Remove unused `ProtocolDomain` and `ProtocolReference` types from schema
- Remove redundant "Protocol Concepts" section from CLAUDE.md
- Add rule 6 to osprotocol-guide: accompany clarifying questions with examples

## Test plan

- [ ] Verify schema package still exports correctly
- [ ] Verify osprotocol-guide follows new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)